### PR TITLE
feat: controlleradvice를 통한 글로벌 에러처리

### DIFF
--- a/src/main/java/org/example/popspace/global/error/CustomException.java
+++ b/src/main/java/org/example/popspace/global/error/CustomException.java
@@ -1,0 +1,10 @@
+package org.example.popspace.global.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/org/example/popspace/global/error/ErrorCode.java
+++ b/src/main/java/org/example/popspace/global/error/ErrorCode.java
@@ -1,0 +1,38 @@
+package org.example.popspace.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    BAD_GATEWAY_TEST(HttpStatus.BAD_GATEWAY,"이거 바꿔야함"),
+    INVALID_ENCRYPTION(HttpStatus.FORBIDDEN,"암호화가 유효하지 않습니다."),
+    SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러입니다. 서버 팀에 연락주세요!"),
+    INVALID_DECRYPTION(HttpStatus.FORBIDDEN,"복호화가 유효하지 않습니다."),
+    UNACCEPT_TOKEN(HttpStatus.UNAUTHORIZED, "Token is null or too short"),
+    BADTYPE_BEARER(HttpStatus.UNAUTHORIZED, "Token type Bearer"),
+    MALFORM_TOKEN(HttpStatus.FORBIDDEN, "Malformed Token"),
+    BADSIGN_TOKEN(HttpStatus.FORBIDDEN, "BadSignatured Token"),
+    EXPIRED_TOKEN(HttpStatus.FORBIDDEN, "Expired Token"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "Unauthorized"),
+    DUPLICATE_USER(HttpStatus.CONFLICT,"Duplicate User" ),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND,"User not found" ),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "Invalid Token" ),
+    NOT_FOUND_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "Access Token not found" ),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "Refresh Token not found" ),
+    NO_PROUDCT(HttpStatus.NOT_FOUND,"No Proudct" ),
+    S3_INVALID(HttpStatus.BAD_REQUEST,"S3 Invalid" ),
+    INVALID_LOGIN_REQUEST(HttpStatus.BAD_REQUEST, "이메일 또는 비밀번호가 누락되었습니다."),
+
+    INVALID_INDEX(HttpStatus.BAD_REQUEST, "잘못된 인덱스입니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "예기치 못한 서버 오류입니다.")
+    ;
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/org/example/popspace/global/error/ErrorDTO.java
+++ b/src/main/java/org/example/popspace/global/error/ErrorDTO.java
@@ -1,0 +1,16 @@
+package org.example.popspace.global.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorDTO {
+
+    private String code;
+    private String message;
+}

--- a/src/main/java/org/example/popspace/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/popspace/global/error/GlobalExceptionHandler.java
@@ -1,0 +1,49 @@
+package org.example.popspace.global.error;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorDTO> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        log.warn("CustomException occurred: {}", errorCode);
+        return handleExceptionInternal(errorCode);
+    }
+
+    @ExceptionHandler(IndexOutOfBoundsException.class)
+    protected ResponseEntity<ErrorDTO> handleIndexOutOfBounds(IndexOutOfBoundsException ex) {
+        log.warn("IndexOutOfBoundsException: {}", ex.getMessage());
+        return handleExceptionInternal(ErrorCode.INVALID_INDEX);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorDTO> handleIllegalArgument(IllegalArgumentException ex) {
+        log.warn("IllegalArgumentException: {}", ex.getMessage());
+        return handleExceptionInternal(ErrorCode.INVALID_INPUT);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorDTO> handleUncaughtException(Exception ex) {
+        log.error("Unhandled Exception", ex);
+        return handleExceptionInternal(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    private ResponseEntity<ErrorDTO> handleExceptionInternal(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getStatus())
+                .body(makeErrorResponse(errorCode));
+    }
+
+    private ErrorDTO makeErrorResponse(ErrorCode errorCode) {
+        return ErrorDTO.builder()
+                .code(errorCode.name())
+                .message(errorCode.getMessage())
+                .build();
+    }
+}


### PR DESCRIPTION


<img width="627" alt="image" src="https://github.com/user-attachments/assets/ada86f66-1687-4582-8d1c-52132db013e1" />


<img width="419" alt="스크린샷 2025-06-02 오전 9 03 25" src="https://github.com/user-attachments/assets/36e44d7a-9982-45f1-903e-b11e4b2d761a" />

글로벌 에러 처리 방법
ErrorCode.enum에 해당한는 httpcode와 상세 메시지 작성-> throw new CustomException(ErrorCode.XXX)를 적용하면 에러 처리되됨
